### PR TITLE
Create surveyModify.java

### DIFF
--- a/src/main/java/com/everytime/Hackathon2025/Controller/surveyModify.java
+++ b/src/main/java/com/everytime/Hackathon2025/Controller/surveyModify.java
@@ -1,0 +1,54 @@
+@Entity
+public class Survey {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+    private LocalDate deadline;
+
+    // Getter, Setter
+}
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+}
+public class SurveyUpdateRequest {
+    private String title;
+    private String description;
+    private LocalDate deadline;
+
+    // Getter, Setter
+}
+@RestController
+@RequestMapping("/api/surveys")
+public class SurveyController {
+
+    private final SurveyRepository surveyRepository;
+
+    public SurveyController(SurveyRepository surveyRepository) {
+        this.surveyRepository = surveyRepository;
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateSurvey(@PathVariable Long id, @RequestBody SurveyUpdateRequest request) {
+        Optional<Survey> optionalSurvey = surveyRepository.findById(id);
+        if (optionalSurvey.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Survey not found");
+        }
+
+        Survey survey = optionalSurvey.get();
+
+        if (request.getTitle() != null) {
+            survey.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            survey.setDescription(request.getDescription());
+        }
+        if (request.getDeadline() != null) {
+            survey.setDeadline(request.getDeadline());
+        }
+
+        surveyRepository.save(survey);
+        return ResponseEntity.ok("Survey updated successfully");
+    }
+}


### PR DESCRIPTION
이 API는 클라이언트가 전달한 설문조사 ID에 해당하는 설문 항목을 수정(update) 합니다. 설문 제목, 설명, 마감일과 같은 정보를 갱신할 수 있습니다.